### PR TITLE
Update Alpha_WGAN_ADNI_train.ipynb

### DIFF
--- a/Alpha_WGAN_ADNI_train.ipynb
+++ b/Alpha_WGAN_ADNI_train.ipynb
@@ -202,7 +202,7 @@
     "        d_fake_loss = D(x_rand).mean()\n",
     "        d_loss = -d_fake_loss-d_real_loss\n",
     "        l1_loss =10* criterion_l1(x_hat,real_images)\n",
-    "        loss1 = l1_loss + c_loss + d_loss\n",
+    "        loss1 = l1_loss + d_loss\n",
     "\n",
     "        if iters<g_iter-1:\n",
     "            loss1.backward()\n",


### PR DESCRIPTION
In https://arxiv.org/pdf/1908.02498.pdf article the generator loss is just calculated using the d_loss and the l1_loss. The c_loss is just used in lossCodeDiscriminator calculation.
Please, let me know if what I said is correct.